### PR TITLE
RHEL patch via yum optimized

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,25 @@
-# Ansible Role: patch_update_yum
+This playbook allows to apply an update of RHEL patch via yum
+==============================================================
 
-An Ansible role that upgrade all packages or security patch only via yum and reboot server (optional) 
+- By default, it updates all the patches and restart the server
 
-# Description 
+- 6 types of update are available
 
-This playbook allows you to apply patch update via yum
-4 types of update available: everything with or without reboot OR security only with or without reboot
-The hosts must be a part of the patch_update_yum group if desired
-You must configure the variables "securite_only" (yes or no) and "reboot" (yes or no) in the group_vars "patch_update_yum" or default wil be all patch with reboot
-You need ansible 2.7 to use the reboot module
+      - All patches with restart
+      - All patches without restart
+      - Security patch only with restart
+      - Security patch only without restart
+      - Custom patch only with restart
+      - Custom patch only without restart
+
+- The following variables must be overwritten only if the default does not suit your need (eg by a group_vars patch_update)
+
+   security_only_required: "no" # yes/no
+   reboot_required: "true"      # true/false
+   package_name: '*'            # yum package name
+   package_state: "latest"      # absent, installed, latest, present, removed
+  
+- You need ansible 2.7 to use the reboot module
 
 
 

--- a/group_vars/patch_update_yum
+++ b/group_vars/patch_update_yum
@@ -1,4 +1,6 @@
 ---
 
-#security_only: "no"  # yes or no
-#reboot:        "yes" # yes or no
+# security_only_required: "no" # yes/no
+# reboot_required: "true"      # true/false
+# package_name: '*'            # yum package name
+# package_state: "latest"      # absent, installed, latest, present, removed

--- a/roles/patch_update_yum/README.md
+++ b/roles/patch_update_yum/README.md
@@ -1,14 +1,25 @@
-# Ansible Role: patch_update_yum
+This playbook allows to apply an update of RHEL patch via yum
+==============================================================
 
-An Ansible role that upgrade all packages or security patch only via yum and reboot server (optional) 
+- By default, it updates all the patches and restart the server
 
-# Description 
+- 6 types of update are available
 
-This playbook allows you to apply patch update via yum
-4 types of update available: everything with or without reboot OR security only with or without reboot
-The hosts must be a part of the patch_update_yum group if desired
-You must configure the variables "securite_only" (yes or no) and "reboot" (yes or no) in the group_vars "patch_update_yum" or default wil be all patch with reboot
-You need ansible 2.7 to use the reboot module
+      - All patches with restart
+      - All patches without restart
+      - Security patch only with restart
+      - Security patch only without restart
+      - Custom patch only with restart
+      - Custom patch only without restart
+
+- The following variables must be overwritten only if the default does not suit your need (eg by a group_vars patch_update)
+
+    security_only_required: "no" # yes/no
+    reboot_required: "true"      # true/false
+    package_name: '*'            # yum package name
+    package_state: "latest"      # absent, installed, latest, present, removed
+  
+- You need ansible 2.7 to use the reboot module
 
 
 

--- a/roles/patch_update_yum/defaults/main.yml
+++ b/roles/patch_update_yum/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
 
-security_only: "no"  # yes or no
-reboot:        "yes" # yes or no
+security_only_required: "no" # yes/no
+reboot_required: "true"      # true/false
+package_name: '*'            # yum package name
+package_state: "latest"      # absent, installed, latest, present, removed
+

--- a/roles/patch_update_yum/handlers/main.yml
+++ b/roles/patch_update_yum/handlers/main.yml
@@ -1,5 +1,6 @@
 ---
-    - name: Server reboot... 
+    - name: Server reboot if needed... 
       reboot:
         pre_reboot_delay: 1
+      when: reboot_required   
 

--- a/roles/patch_update_yum/tasks/main.yml
+++ b/roles/patch_update_yum/tasks/main.yml
@@ -1,37 +1,11 @@
 ---
-# This playbook allows you to apply patch update via yum
-# 4 types of update available: everything with or without reboot OR security only with or without reboot
-# The hosts must be a part of the patch_update_yum group if desired
-# You must configure the variables "securite_only" (yes or no) and "reboot" (yes or no) in the group_vars "patch_update_yum" or default wil be all patch with reboot
-# You need ansible 2.7 to use the reboot module
-
-  - name: Upgrade all yum package with reboot
-    yum:
-        name: '*'
-        state: latest
-    notify:
-           - Server reboot...
-    when: security_only == "no" and reboot == "yes"
-
-  - name: Upgrade all yum package with no reboot
-    yum:
-        name:  '*'
-        state: latest
-    when: security_only == "no" and reboot == "no"
-
-  - name: Upgrade yum security package only with reboot
+ 
+  - name: Package update  
     yum: 
-        name:     '*'
-        state:    latest
-        security: yes
+        name:     "{{ package_name }}"
+        state:    "{{ package_state }}"
+        security: "{{ security_only_required }}"
     notify:
-           - Server reboot...
-    when: security_only == "yes" and reboot == "yes"
+           - Server reboot if needed...
 
-  - name: Upgrade yum security package only with no reboot
-    yum:
-        name:     '*'
-        state:    latest
-        security: yes
-    when: security_only == "yes" and reboot == "no"
-
+...           


### PR DESCRIPTION
This playbook allows to apply an update of RHEL patch via yum
==============================================================

- By default, it updates all the patches and restart the server

- 6 types of update are available

      - All patches with restart
      - All patches without restart
      - Security patch only with restart
      - Security patch only without restart
      - Custom patch only with restart
      - Custom patch only without restart

- The following variables must be overwritten only if the default does not suit your need (eg by a group_vars patch_update)

  security_only_required: "no" # yes/no
     reboot_required: "true"      # true/false
     package_name: '*'            # yum package name
     package_state: "latest"      # absent, installed, latest, present, removed
  
- You need ansible 2.7 to use the reboot module



